### PR TITLE
Add service and tests for QTE target movement

### DIFF
--- a/Source/NotPokemonGo/Assets/Scripts/UI/QTE/QTETargetMovementCalculator.cs
+++ b/Source/NotPokemonGo/Assets/Scripts/UI/QTE/QTETargetMovementCalculator.cs
@@ -1,0 +1,69 @@
+using System;
+using UnityEngine;
+
+namespace UI.QTE
+{
+    public readonly struct QTETargetMovementSnapshot
+    {
+        public QTETargetMovementSnapshot(float normalizedProgress, bool completed, bool failed)
+        {
+            NormalizedProgress = Mathf.Clamp01(normalizedProgress);
+            Completed = completed;
+            Failed = failed;
+        }
+
+        public float NormalizedProgress { get; }
+
+        public bool Completed { get; }
+
+        public bool Failed { get; }
+    }
+
+    public class QTETargetMovementCalculator
+    {
+        private readonly float _speed;
+        private readonly float _pathLength;
+        private readonly float _tolerance;
+
+        private float _distanceTravelled;
+
+        public QTETargetMovementCalculator(float speed, float pathLength, float tolerance)
+        {
+            if (pathLength <= 0f)
+            {
+                throw new ArgumentOutOfRangeException(nameof(pathLength), "Path length must be greater than zero.");
+            }
+
+            if (tolerance < 0f)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tolerance), "Tolerance must be non-negative.");
+            }
+
+            _speed = speed;
+            _pathLength = pathLength;
+            _tolerance = tolerance;
+            _distanceTravelled = 0f;
+        }
+
+        public QTETargetMovementSnapshot Tick(float deltaTime)
+        {
+            if (deltaTime < 0f)
+            {
+                throw new ArgumentOutOfRangeException(nameof(deltaTime), "Delta time must be non-negative.");
+            }
+
+            _distanceTravelled += Mathf.Max(0f, deltaTime * _speed);
+
+            float normalizedProgress = _distanceTravelled / _pathLength;
+            bool completed = _distanceTravelled >= _pathLength;
+            bool failed = _distanceTravelled > _pathLength + _tolerance;
+
+            return new QTETargetMovementSnapshot(normalizedProgress, completed, failed);
+        }
+
+        public void Reset()
+        {
+            _distanceTravelled = 0f;
+        }
+    }
+}

--- a/Source/NotPokemonGo/Assets/Scripts/UI/QTE/QTETargetMovementOnCanvas.cs
+++ b/Source/NotPokemonGo/Assets/Scripts/UI/QTE/QTETargetMovementOnCanvas.cs
@@ -7,39 +7,60 @@ namespace UI.QTE
   public class QTETargetMovementOnCanvas : QTEButtonView
   {
     private const float MaxValue = 1f;
-    
+
     [SerializeField] private Slider _slider;
     [SerializeField] private float _timer;
-    [SerializeField] private float _speed;
+    [SerializeField] private float _speed = 1f;
+    [SerializeField] private float _tolerance = 0.05f;
+
+    private QTETargetMovementCalculator _movementCalculator;
+    private float _remainingTime;
+    private bool _isCompleted;
+    private bool _isFailed;
 
     public override event Action<QTEButtonView> Successed;
     public override event Action<QTEButtonView> Invalided;
 
-    private void OnEnable() => 
-      _slider.onValueChanged.AddListener(OnSliderValueChanged);
-
-    private void OnDisable() => 
-      _slider.onValueChanged.AddListener(OnSliderValueChanged);
-
-    private void OnSliderValueChanged(float value)
+    private void OnEnable()
     {
-      if (Mathf.Approximately(value, MaxValue))
-      {
-        Successed?.Invoke(this);
-      }
+      _movementCalculator = new QTETargetMovementCalculator(_speed, MaxValue, _tolerance);
+      _movementCalculator.Reset();
+      _remainingTime = _timer;
+      _slider.value = 0f;
+      _isCompleted = false;
+      _isFailed = false;
     }
 
     private void Update()
     {
-      if (_timer <= 0)
+      if (_isCompleted || _isFailed)
       {
+        return;
+      }
+
+      _remainingTime -= Time.deltaTime * _speed;
+
+      if (_remainingTime <= 0f)
+      {
+        _isFailed = true;
+        Invalided?.Invoke(this);
+        Debug.Log($"Failed in QTETargetMovementOnCanvas");
+        return;
+      }
+
+      QTETargetMovementSnapshot snapshot = _movementCalculator.Tick(Time.deltaTime);
+      _slider.value = snapshot.NormalizedProgress;
+
+      if (snapshot.Failed)
+      {
+        _isFailed = true;
         Invalided?.Invoke(this);
         Debug.Log($"Failed in QTETargetMovementOnCanvas");
       }
-      else
+      else if (snapshot.Completed)
       {
-        float time = _timer -= (Time.deltaTime * _speed);
-        Debug.Log($"current time in QTETargetMovementOnCanvas - {time}");
+        _isCompleted = true;
+        Successed?.Invoke(this);
       }
     }
   }

--- a/Source/NotPokemonGo/Assets/Tests/QTE/QTE.Tests.asmdef
+++ b/Source/NotPokemonGo/Assets/Tests/QTE/QTE.Tests.asmdef
@@ -1,0 +1,20 @@
+{
+    "name": "QTE.Tests",
+    "rootNamespace": "",
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Source/NotPokemonGo/Assets/Tests/QTE/QTETargetMovementCalculatorTests.cs
+++ b/Source/NotPokemonGo/Assets/Tests/QTE/QTETargetMovementCalculatorTests.cs
@@ -1,0 +1,36 @@
+using NUnit.Framework;
+using UI.QTE;
+
+namespace Tests.QTE
+{
+    public class QTETargetMovementCalculatorTests
+    {
+        [Test]
+        public void Tick_IncreasesProgressAlongPath()
+        {
+            var calculator = new QTETargetMovementCalculator(speed: 0.5f, pathLength: 1f, tolerance: 0.2f);
+
+            QTETargetMovementSnapshot firstStep = calculator.Tick(1f);
+            Assert.That(firstStep.NormalizedProgress, Is.EqualTo(0.5f).Within(0.0001f));
+            Assert.That(firstStep.Completed, Is.False);
+            Assert.That(firstStep.Failed, Is.False);
+
+            QTETargetMovementSnapshot secondStep = calculator.Tick(1f);
+            Assert.That(secondStep.NormalizedProgress, Is.EqualTo(1f).Within(0.0001f));
+            Assert.That(secondStep.Completed, Is.True);
+            Assert.That(secondStep.Failed, Is.False);
+        }
+
+        [Test]
+        public void Tick_FailsWhenExceedingTolerance()
+        {
+            var calculator = new QTETargetMovementCalculator(speed: 1f, pathLength: 1f, tolerance: 0.1f);
+
+            calculator.Tick(1f);
+            QTETargetMovementSnapshot overshoot = calculator.Tick(0.2f);
+
+            Assert.That(overshoot.Failed, Is.True);
+            Assert.That(overshoot.NormalizedProgress, Is.EqualTo(1f));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable calculator that tracks QTE target progress and tolerance without relying on UI components
- rework QTETargetMovementOnCanvas to drive the slider via the calculator while preserving timer-based failure
- introduce a QTE test assembly with unit tests covering progress advancement and tolerance overflow

## Testing
- dotnet test *(fails: command not found in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68e8fb4b67d4832e9db95f0b5690937d